### PR TITLE
Fix performance bug in mutilthread.cpp

### DIFF
--- a/deploy/OCSort/cpp/mutilthread.cpp
+++ b/deploy/OCSort/cpp/mutilthread.cpp
@@ -56,24 +56,24 @@ void processFrame(const cv::Mat& frame, std::vector<Detection>& output, ocsort::
 
         data.push_back(row);
 
-        if (!data.empty()) {
-            std::vector<Eigen::RowVectorXf> res = tracker.update(Vector2Matrix(data));
+        cv::rectangle(frame, box, cv::Scalar(0, 255, 0), 2);
 
-            cv::rectangle(frame, box, cv::Scalar(0, 255, 0), 2);
+        std::string classString = detection.className + '(' + std::to_string(detection.confidence).substr(0, 4) + ')';
+        cv::putText(frame, classString, cv::Point(box.x + 5, box.y + box.height - 10), cv::FONT_HERSHEY_DUPLEX, 0.5, cv::Scalar(0, 255, 0), 1, 0);
+    }
 
-            std::string classString = detection.className + '(' + std::to_string(detection.confidence).substr(0, 4) + ')';
-            cv::putText(frame, classString, cv::Point(box.x + 5, box.y + box.height - 10), cv::FONT_HERSHEY_DUPLEX, 0.5, cv::Scalar(0, 255, 0), 1, 0);
+    if (!data.empty()) {
+        std::vector<Eigen::RowVectorXf> res = tracker.update(Vector2Matrix(data));
 
-            for (auto j : res) {
-                int ID = int(j[4]);
-                int Class = int(j[5]);
-                float conf = j[6];
-                cv::putText(frame, cv::format("ID:%d", ID), cv::Point(j[0], j[1] - 5), 0, 0.5, cv::Scalar(0, 0, 255), 1, cv::LINE_AA);
-                cv::rectangle(frame, cv::Rect(j[0], j[1], j[2] - j[0] + 1, j[3] - j[1] + 1), cv::Scalar(0, 0, 255), 1);
-            }
-
-            data.clear();
+        for (auto j : res) {
+            int ID = int(j[4]);
+            int Class = int(j[5]);
+            float conf = j[6];
+            cv::putText(frame, cv::format("ID:%d", ID), cv::Point(j[0], j[1] - 5), 0, 0.5, cv::Scalar(0, 0, 255), 1, cv::LINE_AA);
+            cv::rectangle(frame, cv::Rect(j[0], j[1], j[2] - j[0] + 1, j[3] - j[1] + 1), cv::Scalar(0, 0, 255), 1);
         }
+
+        data.clear();
     }
 }
 


### PR DESCRIPTION
The function to update the OCSort tracker was being called once for every detection for every frame. This causes significant slowdowns as well as dropping tracks and hurting Kalman Filter performance. I changed it so that the OCSort tracker update is only called once per frame on the entire vector of detections.